### PR TITLE
Many to many bug

### DIFF
--- a/django_lifecycle/__init__.py
+++ b/django_lifecycle/__init__.py
@@ -209,11 +209,17 @@ class LifecycleModelMixin(object):
 
     @cached_property
     def _potentially_hooked_methods(self):
-        skip = ['_potentially_hooked_methods', '_run_hooked_methods']
+        skip = set(
+            ['_potentially_hooked_methods', '_run_hooked_methods'] +
+            self._field_names +
+            self._property_names +
+            self._descriptor_names
+        )
+
         collected = []
 
         for name in dir(self):
-            if name in skip + self._field_names + self._property_names + self._descriptor_names:
+            if name in skip:
                 continue
             
             try:

--- a/django_lifecycle/__init__.py
+++ b/django_lifecycle/__init__.py
@@ -45,6 +45,33 @@ def hook(hook: str, when: str = None, was='*', is_now='*',
     return decorator
     
 
+DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES = []
+if StrictVersion(django.__version__) < StrictVersion('1.9'):
+    from django.db.models.fields.related import SingleRelatedObjectDescriptor, ReverseSingleRelatedObjectDescriptor, \
+        ForeignRelatedObjectsDescriptor, ManyRelatedObjectsDescriptor, ReverseManyRelatedObjectsDescriptor
+    DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES.extend([
+        SingleRelatedObjectDescriptor,
+        ReverseSingleRelatedObjectDescriptor,
+        ForeignRelatedObjectsDescriptor,
+        ManyRelatedObjectsDescriptor,
+        ReverseManyRelatedObjectsDescriptor,
+    ])
+if StrictVersion(django.__version__) >= StrictVersion('1.9'):
+    from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor, \
+        ReverseOneToOneDescriptor, ReverseManyToOneDescriptor, ManyToManyDescriptor
+    DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES.extend([
+        ForwardManyToOneDescriptor,
+        ReverseOneToOneDescriptor,
+        ReverseManyToOneDescriptor,
+        ManyToManyDescriptor,
+    ])
+if StrictVersion(django.__version__) >= StrictVersion('1.11'):
+    from django.db.models.fields.related_descriptors import ForwardOneToOneDescriptor
+    DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES.extend([
+        ForwardOneToOneDescriptor,
+    ])
+DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES = tuple(DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES)
+
 
 class LifecycleModelMixin(object):
 
@@ -157,6 +184,28 @@ class LifecycleModelMixin(object):
 
         return property_names
 
+    @cached_property
+    def _descriptor_names(self):
+        """
+        Attributes which are Django descriptors. These represent a field
+        which is a one-to-many or many-to-many relationship that is
+        potentially defined in another model, and doesn't otherwise appear
+        as a field on this model.
+        """
+
+        descriptor_names = []
+
+        for name in dir(self):
+            try:
+                attr = getattr(type(self), name)
+
+                if isinstance(attr, DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES):
+                    descriptor_names.append(name)
+
+            except AttributeError:
+                pass
+
+        return descriptor_names
 
     @cached_property
     def _potentially_hooked_methods(self):
@@ -164,7 +213,7 @@ class LifecycleModelMixin(object):
         collected = []
 
         for name in dir(self):
-            if name in skip + self._field_names + self._property_names:
+            if name in skip + self._field_names + self._property_names + self._descriptor_names:
                 continue
             
             try:

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -29,4 +29,14 @@ class Migration(migrations.Migration):
                 'abstract': False,
             },
         ),
+
+        migrations.CreateModel(
+            name='Locale',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('code', models.CharField(max_length=20)),
+                ('users', models.ManyToManyField(to='UserAccount')),
+            ],
+        ),
+
     ]

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -71,3 +71,9 @@ class UserAccount(LifecycleModel):
     @cached_property
     def full_name(self):
         return self.first_name + ' ' + self.last_name
+
+
+class Locale(models.Model):
+    code = models.CharField(max_length=20)
+
+    users = models.ManyToManyField(UserAccount)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -7,9 +7,8 @@ from django_lifecycle.models import LifecycleModel
 
 
 class CannotDeleteActiveTrial(Exception):
-    pass 
+    pass
 
-    
 
 class UserAccount(LifecycleModel):
     username = models.CharField(max_length=100)
@@ -22,11 +21,11 @@ class UserAccount(LifecycleModel):
     has_trial = models.BooleanField(default=False)
 
     status = models.CharField(
-        default='active', 
+        default='active',
         max_length=30,
         choices=(
-            ('active', 'Active'), 
-            ('banned', 'Banned'), 
+            ('active', 'Active'),
+            ('banned', 'Banned'),
             ('inactive', 'Inactive')
         )
     )
@@ -35,12 +34,10 @@ class UserAccount(LifecycleModel):
     def lowercase_email(self):
         self.email = self.email.lower()
 
-
     @hook('before_create')
     def timestamp_joined_at(self):
         self.joined_at = timezone.now()
-        
-    
+
     @hook('after_create')
     def do_after_create_jobs(self):
         ## queue background job to process thumbnail image...
@@ -48,17 +45,14 @@ class UserAccount(LifecycleModel):
             'Welcome!', 'Thank you for joining.',
             'from@example.com', ['to@example.com'],
         )
-        
 
     @hook('before_update', when='password', has_changed=True)
     def timestamp_password_change(self):
         self.password_updated_at = timezone.now()
 
-
     @hook('before_delete', when='has_trial', was='*', is_now=True)
     def ensure_trial_not_active(self):
         raise CannotDeleteActiveTrial('Cannot delete trial user!')
-
 
     @hook('after_delete')
     def email_deleted_user(self):
@@ -67,14 +61,12 @@ class UserAccount(LifecycleModel):
             'from@example.com', ['to@example.com'],
         )
 
-
     @hook('after_update', when='status', was='active', is_now='banned')
     def email_banned_user(self):
         mail.send_mail(
             'You have been banned', 'You may or may not deserve it.',
             'from@example.com', ['to@example.com'],
         )
-
 
     @cached_property
     def full_name(self):


### PR DESCRIPTION
This is a bug we have encountered a couple of times. Using Django v2, we have made our `User` model be a `LifecycleModelMixin`, and have various other models that create ManyToManyFields against `User`.

This breaks when we create a new `User`, and the `LifecycleModelMixin` calls the `before_create` hooks. `_potentially_hooked_methods()` doesn't recognise the auto-magically created reverse field of the many-to-many relationship as a Django field, so it tries to get the attribute in order to see if it is a callable marked as a lifecycle hook. However, getting the attribute fails because the reverse many-to-many lookup requires the primary key of the `User` instance, but said primary key does not exist because the instance hasn't been saved yet

I note that there was a brief comment on a similar issue in #1 

To cut a long story short, I reproduced this situation in our tests by simply adding another model with a `ManyToManyField` against `UserAccount`, and then fixed it by skipping attributes that look like a Django relationship descriptor. Apologies if there is a smarter way to do that, but I couldn't find anything better and it seemed consistent with the rest of the module.