### PR TITLE
Revise `tox.ini`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 This project provides a `@hook` decorator as well as a base model and mixin to add lifecycle hooks to your Django models. Django's built-in approach to offering lifecycle hooks is [Signals](https://docs.djangoproject.com/en/dev/topics/signals/). However, my team often finds that Signals introduce unnesseary indirection and are at odds with Django's "fat models" approach.
 
+**Django Lifecycle Hooks** supports Python 3.5, 3.6, and 3.7, Django 2.0.x, 2.1.x, 2.2.x.
+
 In short, you can write model code like this:
 
 ```python

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 toxworkdir={env:TOXWORKDIR:{toxinidir}/.tox}
 envlist =
-    {py34,py35,py36}-django18,
-    {py34,py35,py36}-django111,
-    {py34,py35,py36}-django20
+    {py35,py36,py37}-django20
+    {py35,py36,py37}-django21
+    {py35,py36,py37}-django22
 skip_missing_interpreters = True
 
 [testenv]
@@ -13,6 +13,6 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONWARNINGS=once
 deps =
-    django18: django>=1.8,<1.9
-    django111: django>=1.11,<2.0
     django20: django>=2.0,<2.1
+    django21: django>=2.1,<2.2
+    django22: django>=2.2,<3


### PR DESCRIPTION
This change is needed because of using `is_cached` attribute of `field`
in `_clear_watched_fk_model_cache` method of `LifecycleModelMixin`. This
attribute was added to `ForeignKey` object only in Django 2.0.

Refs: https://github.com/django/django/pull/6721/files#diff-3010fc5a498b7171c342520f34507968R82

* Removed testing on Django versions before 2.0.
* Added testing on Python 3.7. Removed testing on Python 3.4.
* Added testing on Django 2.0, Django 2.1, Django 2.2.

Refs: #23 