### PR TITLE
Added hooks names as variable for easy import and use

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project provides a `@hook` decorator as well as a base model and mixin to a
 In short, you can write model code like this:
 
 ```python
-from django_lifecycle import LifecycleModel, hook
+from django_lifecycle import LifecycleModel, hook, BEFORE_UPDATE, AFTER_UPDATE
 
 
 class Article(LifecycleModel):
@@ -19,11 +19,11 @@ class Article(LifecycleModel):
     status = models.ChoiceField(choices=['draft', 'published'])
     editor = models.ForeignKey(AuthUser)
 
-    @hook('before_update', when='contents', has_changed=True)
+    @hook(BEFORE_UPDATE, when='contents', has_changed=True)
     def on_content_change(self):
         self.updated_at = timezone.now()
 
-    @hook('after_update', when="status", was="draft", is_now="published")
+    @hook(AFTER_UPDATE, when="status", was="draft", is_now="published")
     def on_publish(self):
         send_email(self.editor.email, "An article has published!")
 ```

--- a/django_lifecycle/__init__.py
+++ b/django_lifecycle/__init__.py
@@ -7,6 +7,7 @@ class NotSet(object):
 
 from .decorators import hook
 from .mixins import LifecycleModelMixin
+from .hooks import *
 
 
 if IS_GTE_1_POINT_9:

--- a/django_lifecycle/decorators.py
+++ b/django_lifecycle/decorators.py
@@ -3,21 +3,11 @@ from typing import List
 
 from django_lifecycle import NotSet
 
+from .hooks import VALID_HOOKS
+
 
 class DjangoLifeCycleException(Exception):
     pass
-
-
-VALID_HOOKS = (
-    "before_save",
-    "after_save",
-    "before_create",
-    "after_create",
-    "before_update",
-    "after_update",
-    "before_delete",
-    "after_delete",
-)
 
 
 def _validate_hook_params(hook, when, when_any, has_changed):

--- a/django_lifecycle/hooks.py
+++ b/django_lifecycle/hooks.py
@@ -1,0 +1,23 @@
+BEFORE_SAVE = "before_save"
+AFTER_SAVE = "after_save"
+
+BEFORE_CREATE = "before_create"
+AFTER_CREATE = "after_create"
+
+BEFORE_UPDATE = "before_update"
+AFTER_UPDATE = "after_update"
+
+BEFORE_DELETE = "before_delete"
+AFTER_DELETE = "after_delete"
+
+
+VALID_HOOKS = (
+    BEFORE_SAVE,
+    AFTER_SAVE,
+    BEFORE_CREATE,
+    AFTER_CREATE,
+    BEFORE_UPDATE,
+    AFTER_UPDATE,
+    BEFORE_DELETE,
+    AFTER_DELETE
+)


### PR DESCRIPTION
Static typed variables will be easy to use. No breaking changes, previous method also works.  

```python
from django_lifecycle import LifecycleModel, hook, BEFORE_UPDATE, AFTER_UPDATE

@hook(AFTER_UPDATE, when="status", was="draft", is_now="published")
def method_action():
    pass
```
------------------------------ vs ------------------------------
```python3
from django_lifecycle import LifecycleModel, hook

@hook('after_update', when="status", was="draft", is_now="published")
def method_action():
    pass
```