### PR TITLE
Use constants for hook names

### DIFF
--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -5,8 +5,13 @@ from typing import Any, List
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.utils.functional import cached_property
 
-from django_lifecycle import NotSet
-
+from . import NotSet
+from .hooks import (
+    BEFORE_CREATE, BEFORE_UPDATE,
+    BEFORE_SAVE, BEFORE_DELETE,
+    AFTER_CREATE, AFTER_UPDATE,
+    AFTER_SAVE, AFTER_DELETE,
+)
 from .utils import get_unhookable_attribute_names
 
 
@@ -115,25 +120,25 @@ class LifecycleModelMixin(object):
         is_new = self._state.adding
 
         if is_new:
-            self._run_hooked_methods("before_create")
+            self._run_hooked_methods(BEFORE_CREATE)
         else:
-            self._run_hooked_methods("before_update")
+            self._run_hooked_methods(BEFORE_UPDATE)
 
-        self._run_hooked_methods("before_save")
+        self._run_hooked_methods(BEFORE_SAVE)
         save(*args, **kwargs)
-        self._run_hooked_methods("after_save")
+        self._run_hooked_methods(AFTER_SAVE)
 
         if is_new:
-            self._run_hooked_methods("after_create")
+            self._run_hooked_methods(AFTER_CREATE)
         else:
-            self._run_hooked_methods("after_update")
+            self._run_hooked_methods(AFTER_UPDATE)
 
         self._initial_state = self._snapshot_state()
 
     def delete(self, *args, **kwargs):
-        self._run_hooked_methods("before_delete")
+        self._run_hooked_methods(BEFORE_DELETE)
         super().delete(*args, **kwargs)
-        self._run_hooked_methods("after_delete")
+        self._run_hooked_methods(AFTER_DELETE)
 
     @cached_property
     def _potentially_hooked_methods(self):

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,7 +7,7 @@ For simple cases, you might always want something to happen at a certain point, 
 When a user is first created, you could process a thumbnail image in the background and send the user an email:
 
 ```python
-    @hook('after_create')
+    @hook(AFTER_CREATE)
     def do_after_create_jobs(self):
         enqueue_job(process_thumbnail, self.picture_url)
 
@@ -20,7 +20,7 @@ When a user is first created, you could process a thumbnail image in the backgro
 Or you want to email a user when their account is deleted. You could add the decorated method below:
 
 ```python
-    @hook('after_delete')
+    @hook(AFTER_DELETE)
     def email_deleted_user(self):
         mail.send_mail(
             'We have deleted your account', 'We will miss you!.',
@@ -35,7 +35,7 @@ Read on to see how to only fire the hooked method if certain conditions about th
 Maybe you only want the hooked method to run under certain circumstances related to the state of your model. If a model's `status` field change from `"active"` to `"banned"`, you may want to send an email to the user:
 
 ```python
-    @hook('after_update', when='status', was='active', is_now='banned')
+    @hook(AFTER_UPDATE, when='status', was='active', is_now='banned')
     def email_banned_user(self):
         mail.send_mail(
             'You have been banned', 'You may or may not deserve it.',
@@ -50,7 +50,7 @@ The `was` and `is_now` keyword arguments allow you to compare the model's state 
 You can also enforce certain dissallowed transitions. For example, maybe you don't want your staff to be able to delete an active trial because they should expire instead:
 
 ```python
-    @hook('before_delete', when='has_trial', is_now=True)
+    @hook(BEFORE_DELETE, when='has_trial', is_now=True)
     def ensure_trial_not_active(self):
         raise CannotDeleteActiveTrial('Cannot delete trial user!')
 ```
@@ -62,7 +62,7 @@ We've ommitted the `was` keyword meaning that the initial state of the `has_tria
 You can pass the keyword argument `has_changed=True` to run the hooked method if a field has changed.
 
 ```python
-    @hook('before_update', when='address', has_changed=True)
+    @hook(BEFORE_UPDATE, when='address', has_changed=True)
     def timestamp_address_change(self):
         self.address_updated_at = timezone.now()
 ```
@@ -72,7 +72,7 @@ You can pass the keyword argument `has_changed=True` to run the hooked method if
 You can have a hooked method fire when a field's value IS NOT equal to a certain value.
 
 ```python
-    @hook('before_save', when='email', is_not=None)
+    @hook(BEFORE_SAVE, when='email', is_not=None)
     def lowercase_email(self):
         self.email = self.email.lower()
 ```
@@ -82,7 +82,7 @@ You can have a hooked method fire when a field's value IS NOT equal to a certain
 You can have a hooked method fire when a field's initial value was not equal to a specific value.
 
 ```python
-    @hook('before_save', when='status', was_not="rejected", is_now="published")
+    @hook(BEFORE_SAVE, when='status', was_not="rejected", is_now="published")
     def send_publish_alerts(self):
         send_mass_email()
 ```
@@ -93,7 +93,7 @@ You can have a hooked method fire when a field's initial value was not equal to 
 but now is.
 
 ```python
-    @hook('before_save', when='status', changes_to="published")
+    @hook(BEFORE_SAVE, when='status', changes_to="published")
     def send_publish_alerts(self):
         send_mass_email()
 ```
@@ -102,7 +102,7 @@ Generally, `changes_to` is a shorthand for the situation when `was_not` and `is_
 same value. The sample above is equal to:
 
 ```python
-    @hook('before_save', when='status', was_not="published", is_now="published")
+    @hook(BEFORE_SAVE, when='status', was_not="published", is_now="published")
     def send_publish_alerts(self):
         send_mass_email()
 ```
@@ -112,8 +112,8 @@ same value. The sample above is equal to:
 You can decorate the same method multiple times if you want to hook a method to multiple moments.
 
 ```python
-    @hook("after_update", when="published", has_changed=True)
-    @hook("after_create", when="type", has_changed=True)
+    @hook(AFTER_UPDATE, when="published", has_changed=True)
+    @hook(AFTER_CREATE, when="type", has_changed=True)
     def handle_update(self):
         # do something
 ```
@@ -123,7 +123,7 @@ You can decorate the same method multiple times if you want to hook a method to 
 If you want to hook into the same moment, but base its conditions on multiple fields, you can use the `when_any` parameter.
 
 ```python
-    @hook('before_save', when_any=['status', 'type'], has_changed=True)
+    @hook(BEFORE_SAVE, when_any=['status', 'type'], has_changed=True)
     def do_something(self):
         # do something
 ```
@@ -133,7 +133,7 @@ If you want to hook into the same moment, but base its conditions on multiple fi
 If you need to hook into events with more complex conditions, you can take advantage of `has_changed` and `initial_value` [utility methods](advanced.md):
 
 ```python
-    @hook('after_update')
+    @hook(AFTER_UPDATE)
     def on_update(self):
         if self.has_changed('username') and not self.has_changed('password'):
             # do the thing here

--- a/docs/fk_changes.md
+++ b/docs/fk_changes.md
@@ -14,7 +14,7 @@ class UserAccount(LifecycleModel):
     email = models.CharField(max_length=600)
     employer = models.ForeignKey(Organization, on_delete=models.SET_NULL)
 
-    @hook("after_update", when="employer", has_changed=True)
+    @hook(AFTER_UPDATE, when="employer", has_changed=True)
     def notify_user_of_employer_change(self):
         mail.send_mail("Update", "You now work for someone else!", [self.email])
 ```
@@ -34,7 +34,7 @@ class UserAccount(LifecycleModel):
     email = models.CharField(max_length=600)
     employer = models.ForeignKey(Organization, on_delete=models.SET_NULL)
 
-    @hook("after_update", when="employer.name", has_changed=True, is_now="Google")
+    @hook(AFTER_UPDATE, when="employer.name", has_changed=True, is_now="Google")
     def notify_user_of_google_buy_out(self):
         mail.send_mail("Update", "Google bought your employer!", ["to@example.com"],)
 ```

--- a/docs/hooks_and_conditions.md
+++ b/docs/hooks_and_conditions.md
@@ -1,6 +1,8 @@
 # Available Hooks & Conditions
 
-You can hook into one or more lifecycle moments by adding the `@hook` decorator to a model's method. The moment name is passed as the first positional argument, `@hook('before_create')`, and optional keyword arguments can be passed to set up conditions for when the method should fire.
+You can hook into one or more lifecycle moments by adding the `@hook` decorator to a model's method. The moment name
+ is passed as the first positional argument, `@hook(BEFORE_CREATE)`, and optional keyword arguments can be passed to
+  set up conditions for when the method should fire.
 
 ## Decorator Signature
 
@@ -21,16 +23,19 @@ You can hook into one or more lifecycle moments by adding the `@hook` decorator 
 
 Below is a full list of hooks, in the same order in which they will get called during the respective operations:
 
-| Hook name       | When it fires   |
-|:-------------:|:-------------:|
-| before_save | Immediately before `save` is called |
-| after_save | Immediately after `save` is called
-| before_create | Immediately before `save` is called, if `pk` is `None` |
-| after_create | Immediately after `save` is called, if `pk` was initially `None` |
-| before_update | Immediately before `save` is called, if `pk` is NOT `None` |
-| after_update | Immediately after `save` is called, if `pk` was NOT `None` |
-| before_delete | Immediately before `delete` is called |
-| after_delete | Immediately after `delete` is called |
+| Hook constant   | Hook name     | When it fires   |
+|:---------------:|:-------------:|:----------------|
+| `BEFORE_SAVE`   | before_save   | Immediately before `save` is called |
+| `AFTER_SAVE`    | after_save    | Immediately after `save` is called
+| `BEFORE_CREATE` | before_create | Immediately before `save` is called, if `pk` is `None` |
+| `AFTER_CREATE`  | after_create  | Immediately after `save` is called, if `pk` was initially `None` |
+| `BEFORE_UPDATE` | before_update | Immediately before `save` is called, if `pk` is NOT `None` |
+| `AFTER_UPDATE`  | after_update  | Immediately after `save` is called, if `pk` was NOT `None` |
+| `BEFORE_DELETE` | before_delete | Immediately before `delete` is called |
+| `AFTER_DELETE`  | after_delete  | Immediately after `delete` is called |
+
+All of hook constants are strings containing the specific hook name, for example `AFTER_UPDATE` is string
+ `"after_update"` - preferably way is to use hook constant.  
 
 
 ## Condition Keyward Arguments

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ This project provides a `@hook` decorator as well as a base model and mixin to a
 In short, you can write model code like this:
 
 ```python
-from django_lifecycle import LifecycleModel, hook
+from django_lifecycle import LifecycleModel, hook, BEFORE_UPDATE, AFTER_UPDATE
 
 
 class Article(LifecycleModel):
@@ -17,11 +17,11 @@ class Article(LifecycleModel):
     status = models.ChoiceField(choices=['draft', 'published'])
     editor = models.ForeignKey(AuthUser)
 
-    @hook('before_update', when='contents', has_changed=True)
+    @hook(BEFORE_UPDATE, when='contents', has_changed=True)
     def on_content_change(self):
         self.updated_at = timezone.now()
 
-    @hook('after_update', when="status", was="draft", is_now="published")
+    @hook(AFTER_UPDATE, when="status", was="draft", is_now="published")
     def on_publish(self):
         send_email(self.editor.email, "An article has published!")
 ```


### PR DESCRIPTION
#41 adds constants for hook names, but these constants were not used in docs and in the implementation.
This PR changes all occurrences of hardcoded hook names to their constant representation - in docs and also in implementation in `LifecycleModelMixin`.