### PR TITLE
Added support for Python 3.8 and Django 3.0 #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This project provides a `@hook` decorator as well as a base model and mixin to add lifecycle hooks to your Django models. Django's built-in approach to offering lifecycle hooks is [Signals](https://docs.djangoproject.com/en/dev/topics/signals/). However, my team often finds that Signals introduce unnecessary indirection and are at odds with Django's "fat models" approach.
 
-**Django Lifecycle Hooks** supports Python 3.5, 3.6, and 3.7, Django 2.0.x, 2.1.x, 2.2.x.
+**Django Lifecycle Hooks** supports Python 3.5, 3.6, 3.7 and 3.8, Django 2.0.x, 2.1.x, 2.2.x and 3.0.x.
 
 In short, you can write model code like this:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Click==7.0
-Django==2.2.10
+Django==3.0.6
 djangorestframework==3.9.4
 Jinja2==2.11.1
 livereload==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
 ]
 setup(
     name="django-lifecycle",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ toxworkdir={env:TOXWORKDIR:{toxinidir}/.tox}
 envlist =
     {py35,py36,py37}-django20
     {py35,py36,py37}-django21
-    {py35,py36,py37}-django22
+    {py36,py37,py38}-django22
+    {py36,py37,py38}-django30
 skip_missing_interpreters = True
 
 [testenv]
@@ -16,3 +17,4 @@ deps =
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2,<3
+    django30: django>=3.0,<3.1


### PR DESCRIPTION
Library is already supporting py3.8 and Django3.0, so no changes needed.
Support has been added to test matrix for tox and to readme. #45 