### PR TITLE
Feature: hooked methods cached on class

### DIFF
--- a/django_lifecycle/__init__.py
+++ b/django_lifecycle/__init__.py
@@ -1,4 +1,8 @@
-from .django_info import IS_GTE_1_POINT_9
+from distutils.version import StrictVersion
+
+import django
+
+IS_DJANGO_GTE_1_POINT_9 = StrictVersion(django.__version__) >= StrictVersion("1.9")
 
 
 class NotSet(object):
@@ -9,6 +13,5 @@ from .decorators import hook
 from .mixins import LifecycleModelMixin
 from .hooks import *
 
-
-if IS_GTE_1_POINT_9:
+if IS_DJANGO_GTE_1_POINT_9:
     from .models import LifecycleModel

--- a/django_lifecycle/django_info.py
+++ b/django_lifecycle/django_info.py
@@ -1,6 +1,9 @@
+import warnings
 from distutils.version import StrictVersion
 
 import django
+
+warnings.warn("Module django_info is unused by django_lifecycle itself and will be removed.", DeprecationWarning)
 
 DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES = []
 
@@ -44,7 +47,6 @@ if StrictVersion(django.__version__) >= StrictVersion("1.11"):
     from django.db.models.fields.related_descriptors import ForwardOneToOneDescriptor
 
     DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES.extend([ForwardOneToOneDescriptor])
-
 
 DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES = tuple(DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES)
 IS_GTE_1_POINT_9 = StrictVersion(django.__version__) >= StrictVersion("1.9")

--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -157,7 +157,7 @@ class LifecycleModelMixin(object):
         return collected
 
     @cached_class_property
-    def _watched_fk_model_fields(self) -> List[str]:
+    def _watched_fk_model_fields(cls) -> List[str]:
         """
             Gather up all field names (values in 'when' key) that correspond to
             field names on FK-related models. These will be strings that contain
@@ -165,7 +165,7 @@ class LifecycleModelMixin(object):
         """
         watched = []  # List[str]
 
-        for method in self._potentially_hooked_methods:
+        for method in cls._potentially_hooked_methods:
             for specs in method._hooked:
                 if specs["when"] is not None and "." in specs["when"]:
                     watched.append(specs["when"])
@@ -173,8 +173,8 @@ class LifecycleModelMixin(object):
         return watched
 
     @cached_class_property
-    def _watched_fk_models(self) -> List[str]:
-        return [_.split(".")[0] for _ in self._watched_fk_model_fields]
+    def _watched_fk_models(cls) -> List[str]:
+        return [_.split(".")[0] for _ in cls._watched_fk_model_fields]
 
     def _run_hooked_methods(self, hook: str) -> List[str]:
         """

--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -2,7 +2,6 @@ from functools import reduce
 from typing import Any, List
 
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
-from django.db.models.base import ModelBase
 
 from . import NotSet
 from .decorators import HookedMethod
@@ -135,15 +134,8 @@ class LifecycleModelMixin(object):
         # really important to skip _potentially_hooked_methods to avoid recursion
         skip |= set(dir(LifecycleModelMixin))
 
-        # collect attributes from models:
-        # * from classes in MRO line
-        # * including only instances of Django meta class ModelBase (so no object and no mixins)
-        # * excluding last in line, which is django Model itself
-        to_dir = [set(dir(cls)) for cls in cls.mro() if isinstance(cls, ModelBase)][:-1]
-
-        possible_names = set()
-        for parent_dir in to_dir:
-            possible_names |= parent_dir
+        # collect all possible hooked attrs from class
+        possible_names = set(dir(cls))
 
         collected = []
         for name in possible_names - skip:

--- a/django_lifecycle/utils.py
+++ b/django_lifecycle/utils.py
@@ -3,30 +3,6 @@ from typing import Set
 
 from django.db.models.base import ModelBase
 
-from .django_info import DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES
-
-
-def _get_model_descriptor_names(klass: ModelBase) -> Set[str]:
-    """
-    Attributes which are Django descriptors. These represent a field
-    which is a one-to-many or many-to-many relationship that is
-    potentially defined in another model, and doesn't otherwise appear
-    as a field on this model.
-    """
-
-    descriptor_names = set()
-
-    for name in dir(klass):
-        try:
-            attr = getattr(type(klass), name)
-
-            if isinstance(attr, DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES):
-                descriptor_names.add(name)
-        except AttributeError:
-            pass
-
-    return descriptor_names
-
 
 def _get_field_names(klass: ModelBase) -> Set[str]:
     names = set()
@@ -44,7 +20,6 @@ def _get_field_names(klass: ModelBase) -> Set[str]:
 def get_unhookable_attribute_names(klass) -> Set[str]:
     return (
             _get_field_names(klass) |
-            _get_model_descriptor_names(klass) |
             {'MultipleObjectsReturned', 'DoesNotExist'}
     )
 

--- a/django_lifecycle/utils.py
+++ b/django_lifecycle/utils.py
@@ -2,30 +2,8 @@ from functools import wraps
 from typing import Set
 
 from django.db.models.base import ModelBase
-from django.utils.functional import cached_property
 
 from .django_info import DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES
-
-
-def _get_model_property_names(klass: ModelBase) -> Set[str]:
-    """
-        Gather up properties and cached_properties which may be methods
-        that were decorated. Need to inspect class versions b/c doing
-        getattr on them could cause unwanted side effects.
-    """
-    property_names = set()
-
-    for name in dir(klass):
-        try:
-            attr = getattr(type(klass), name)
-
-            if isinstance(attr, property) or isinstance(attr, cached_property):
-                property_names.add(name)
-
-        except AttributeError:
-            pass
-
-    return property_names
 
 
 def _get_model_descriptor_names(klass: ModelBase) -> Set[str]:
@@ -67,7 +45,6 @@ def get_unhookable_attribute_names(klass) -> Set[str]:
     return (
             _get_field_names(klass) |
             _get_model_descriptor_names(klass) |
-            _get_model_property_names(klass) |
             {'MultipleObjectsReturned', 'DoesNotExist'}
     )
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -3,7 +3,8 @@ import uuid
 from django.utils import timezone
 from django.core import mail
 from django.db import models
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property as django_cached_property
+from functools import cached_property as builtin_cached_property
 from django_lifecycle import hook
 from django_lifecycle.models import LifecycleModel
 
@@ -119,9 +120,13 @@ class UserAccount(LifecycleModel):
             ["to@example.com"],
         )
 
-    @cached_property
+    @django_cached_property
     def full_name(self):
         return self.first_name + " " + self.last_name
+
+    @builtin_cached_property
+    def full_name_with_email(self):
+        return self.first_name + " " + self.last_name + " (" + (self.email or '') + ")"
 
 
 class Locale(models.Model):

--- a/tests/testapp/tests/test_decorator.py
+++ b/tests/testapp/tests/test_decorator.py
@@ -16,5 +16,5 @@ class DecoratorTests(TestCase):
                 pass
 
         instance = FakeModel()
-        self.assertEqual(len(instance.multiple_hooks._hooked), 2)
-        self.assertEqual(len(instance.one_hook._hooked), 1)
+        self.assertEqual(len(type(instance).multiple_hooks._hooked), 2)
+        self.assertEqual(len(type(instance).one_hook._hooked), 1)

--- a/tests/testapp/tests/test_mixin.py
+++ b/tests/testapp/tests/test_mixin.py
@@ -324,9 +324,9 @@ class LifecycleMixinTests(TestCase):
         user_account.last_name = "Bouvier"
         user_account.save()  # `CannotRename` exception is not raised
 
-    def test_should_not_call_cached_property(self):
+    def test_should_not_call_django_cached_property(self):
         """
-            full_name is cached_property. Accessing _potentially_hooked_methods
+            full_name is cached_property (Django). Accessing _potentially_hooked_methods
             should not call it incidentally.
         """
         data = self.stub_data
@@ -337,6 +337,21 @@ class LifecycleMixinTests(TestCase):
         account.first_name = "Bartholomew"
         # Should be first time this property is accessed...
         self.assertEqual(account.full_name, "Bartholomew Simpson")
+
+    def test_should_not_call_builtin_cached_property(self):
+        """
+            full_name is cached_property. Accessing _potentially_hooked_methods
+            should not call it incidentally.
+        """
+        data = self.stub_data
+        data["first_name"] = "Bart"
+        data["last_name"] = "Simpson"
+        data["email"] = "bart@simpson.com"
+        account = UserAccount.objects.create(**data)
+        account._potentially_hooked_methods
+        account.first_name = "Bartholomew"
+        # Should be first time this property is accessed...
+        self.assertEqual(account.full_name_with_email, "Bartholomew Simpson (bart@simpson.com)")
 
     def test_comparison_state_should_reset_after_save(self):
         data = self.stub_data

--- a/tests/testapp/tests/test_user_account.py
+++ b/tests/testapp/tests/test_user_account.py
@@ -97,9 +97,9 @@ class UserAccountTestCase(TestCase):
         account.save()
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(
-            mail.outbox[0].subject, "The name of your organization has changed!"
+            {mail.outbox[0].subject, mail.outbox[1].subject},
+            {"The name of your organization has changed!", "You were moved to our online school!"}
         )
-        self.assertEqual(mail.outbox[1].subject, "You were moved to our online school!")
 
     def test_email_user_about_name_change(self):
         account = UserAccount.objects.create(**self.stub_data)


### PR DESCRIPTION
## Motivation

#### 1. `_get_model_property_names`
Utility function `_get_model_property_names` is currently used for getting attribute names of properties to avoid potential side-effects during getting them. This workaround is great, but it isn't covering all possible properties types (e.g. `functools.cached_property`), only builtin `property` and `cached_property` from Django.
#### 2. `_potentially_hooked_methods` cached on instance
Since `_potentially_hooked_methods` use `cached_property`, the results are cached on an instance, not on class -- but in my opinion, it's useless to have them valid for instance. Except for edge cases (dynamic definition of a method with hook during runtime) are the hooked methods the same for all instances of one model class. Because of that, `_potentially_hooked_methods` is evaluated 1000 times in this code:
```python
[ModelInheritedFromLifecycleMixin() for _ in range(1000)]
```
That's measurable and unnecessary performance effect on model runtime (especially in combination with first point).
#### 3. depth of searching in `_potentially_hooked_methods`
This method is currently using `dir(self)` to inspect all possible attributes with a hook -- that means scanning all delivered attributes from base DjangoModels and this is really unnecessary since `@hook` could be only on user's code, not on code from Django. 

## Solution

This PR contains refactoring of `@hook` decorator and part of `LifecycleMixin` code to use class-based cache to avoid problems mentioned above (evaluation of `_potentially_hooked_methods` for each new instance of model and evaluation of not known property types). Methods for scanning for possible hooks are now taken only from children's classes, not from Django Models.

PR is without BC break IMHO, if you don't use internals (accessing `._hooked` manually, relying on the order of hooks evaluation or using `@hook` higher in the class tree than `LifecycleMixin`).

## Questions
1. order of hook evaluation
hooked methods in tests
https://github.com/rsinger86/django-lifecycle/blob/a77e05c3376707b06dc765911968ad5fa37b168c/tests/testapp/models.py#L72-L93
and surrounding test method
https://github.com/rsinger86/django-lifecycle/blob/a77e05c3376707b06dc765911968ad5fa37b168c/tests/testapp/tests/test_user_account.py#L88-L102

The test is currently expecting a specific order of hooks evaluation since both hooks are on the same attribute. Is it a wanted feature?
I don't think so, hooked methods *should not* affect each other, and hooks shall have undeterminable order of evaluation. This PR also changes the way of working with excluded attributes internally, now is used sets and not lists (and that's the problem for the hooks order evaluation). 

2. `_get_model_descriptor_names`
There is no test for this method, respectively in all test cases this method returns empty iterable. What's the use case for this functionality? 