### PR TITLE
Allow triggering a hook when ANY field changes

### DIFF
--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -192,6 +192,7 @@ class LifecycleModelMixin(object):
 
                 when_field = callback_specs.get("when")
                 when_any_field = callback_specs.get("when_any")
+                has_changed = callback_specs.get("has_changed")
 
                 if when_field:
                     if self._check_callback_conditions(when_field, callback_specs):
@@ -202,6 +203,10 @@ class LifecycleModelMixin(object):
                         if self._check_callback_conditions(field_name, callback_specs):
                             fired.append(method.__name__)
                             method()
+                elif has_changed:
+                    if self._diff_with_initial:
+                        fired.append(method.__name__)
+                        method()
                 else:
                     fired.append(method.__name__)
                     method()

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -128,6 +128,17 @@ If you want to hook into the same moment, but base its conditions on multiple fi
         # do something
 ```
 
+## Watching any fields
+
+If you want a hook to fire if _any_ field changes for a model, then don't
+include `when` or `when_any`.
+
+```python
+    @hook(BEFORE_SAVE, has_changed=True)
+    def do_something(self):
+        # do something
+```
+
 ## Going deeper with utility methods
 
 If you need to hook into events with more complex conditions, you can take advantage of `has_changed` and `initial_value` [utility methods](advanced.md):

--- a/docs/hooks_and_conditions.md
+++ b/docs/hooks_and_conditions.md
@@ -46,7 +46,7 @@ If you do not use any conditional parameters, the hook will fire every time the 
 |:-------------:|:-------------:|:-------------:|
 | when | str | The name of the field that you want to check against; required for the conditions below to be checked. Use the name of a FK field to watch changes to the related model *reference* or use dot-notation to watch changes to the *values* of fields on related models, e.g. `"organization.name"`. But [please be aware](fk_changes.md#fk-hook-warning) of potential performance drawbacks. |
 | when_any | List[str] | Similar to the `when` parameter, but takes a list of field names. The hooked method will fire if any of the corresponding fields meet the keyword conditions. Useful if you don't like stacking decorators. |
-| has_changed | bool | Only fire the hooked method if the value of the `when` field has changed since the model was initialized  |
+| has_changed | bool | Only fire the hooked method if the value of the `when` field has changed since the model was initialized. If `when` is undefined, the hook only fires if ANY field has changed.  |
 | is_now | any | Only fire the hooked method if the value of the `when` field is currently equal to this value; defaults to `*`.  |
 | is_not | any | Only fire the hooked method if the value of the `when` field is NOT equal to this value  |
 | was | any | Only fire the hooked method if the value of the `when` field was equal to this value when first initialized; defaults to `*`.  |

--- a/tests/testapp/tests/test_mixin.py
+++ b/tests/testapp/tests/test_mixin.py
@@ -169,6 +169,46 @@ class LifecycleMixinTests(TestCase):
         fired_methods = instance._run_hooked_methods("after_create")
         self.assertEqual(fired_methods, ["method_that_does_fires"])
 
+    def test_run_hooked_methods_for_has_changed(self):
+        instance = UserAccount(first_name="Bob")
+
+        instance._potentially_hooked_methods = [
+            MagicMock(
+                __name__="method_that_does_fires",
+                _hooked=[
+                    {
+                        "hook": "after_create",
+                        "when": None,
+                        "when_any": None,
+                        "has_changed": None,
+                        "is_now": "Bob",
+                        "is_not": NotSet,
+                        "was": "*",
+                        "was_not": NotSet,
+                        "changes_to": NotSet,
+                    }
+                ],
+            ),
+            MagicMock(
+                __name__="method_that_does_not_fire",
+                _hooked=[
+                    {
+                        "hook": "after_create",
+                        "when": None,
+                        "when_any": None,
+                        "has_changed": None,
+                        "is_now": "Bill",
+                        "is_not": NotSet,
+                        "was": "*",
+                        "was_not": NotSet,
+                        "changes_to": NotSet,
+                    }
+                ],
+            ),
+        ]
+        fired_methods = instance._run_hooked_methods("after_create")
+        self.assertEqual(fired_methods, ["method_that_does_fires"])
+
     def test_has_changed(self):
         data = self.stub_data
         data["username"] = "Joe"


### PR DESCRIPTION
This small change allows triggering a hook when any field for a model changes.

Unlike `when_any`, this doesn't require enumerating all fields, which can be a pain for very large model, and it can be very easy to forget about fields when adding them to the model.

Docs and tests should clarify any final details around this.