### PR TITLE
Skip GenericForeignKey fields

### DIFF
--- a/django_lifecycle/utils.py
+++ b/django_lifecycle/utils.py
@@ -54,8 +54,14 @@ def _get_field_names(instance) -> List[str]:
     for f in instance._meta.get_fields():
         names.append(f.name)
 
-        if instance._meta.get_field(f.name).get_internal_type() == "ForeignKey":
-            names.append(f.name + "_id")
+        try:
+            internal_type = instance._meta.get_field(f.name).get_internal_type()
+        except AttributeError:
+            # Skip fields which don't provide a `get_internal_type` method, e.g. GenericForeignKey
+            continue
+        else:
+            if internal_type == "ForeignKey":
+                names.append(f.name + "_id")
 
     return names
 


### PR DESCRIPTION
The `GenericForeignKey` field does not provide a `get_internal_type`
method so when checking if it's a ForeignKey or not an AttributeError is
raised.

This adjusts the code to ignore this `AttributeError` which effectively
un-monitors the `GenericForeignKey` itself. However, it does leave the
underlying `ForeignKey` to the `ContentType` table and the primary key
storage field indexing into that table monitored. This does not enable
support for hooking on the name of the `GenericForeignKey`, but hooking
on the underlying fields that support that `GenericForeignKey` should
still be possible.

closes #42 