### PR TITLE
Switching from distutils to packaging.version for version checking

### DIFF
--- a/django_lifecycle/django_info.py
+++ b/django_lifecycle/django_info.py
@@ -1,10 +1,10 @@
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 import django
 
 DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES = []
 
-if StrictVersion(django.__version__) < StrictVersion("1.9"):
+if Version(django.__version__) < Version("1.9"):
     from django.db.models.fields.related import (
         SingleRelatedObjectDescriptor,
         ReverseSingleRelatedObjectDescriptor,
@@ -23,7 +23,7 @@ if StrictVersion(django.__version__) < StrictVersion("1.9"):
         ]
     )
 
-if StrictVersion(django.__version__) >= StrictVersion("1.9"):
+if Version(django.__version__) >= Version("1.9"):
     from django.db.models.fields.related_descriptors import (
         ForwardManyToOneDescriptor,
         ReverseOneToOneDescriptor,
@@ -40,11 +40,11 @@ if StrictVersion(django.__version__) >= StrictVersion("1.9"):
         ]
     )
 
-if StrictVersion(django.__version__) >= StrictVersion("1.11"):
+if Version(django.__version__) >= Version("1.11"):
     from django.db.models.fields.related_descriptors import ForwardOneToOneDescriptor
 
     DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES.extend([ForwardOneToOneDescriptor])
 
 
 DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES = tuple(DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES)
-IS_GTE_1_POINT_9 = StrictVersion(django.__version__) >= StrictVersion("1.9")
+IS_GTE_1_POINT_9 = Version(django.__version__) >= Version("1.9")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
 import os
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 import django
 
@@ -43,7 +43,7 @@ INSTALLED_APPS = [
 ]
 
 # Django 1.8 requires that abstract model app is in INSTALLED_APPS
-if StrictVersion("1.8") <= StrictVersion(django.__version__) < StrictVersion("1.9"):
+if Version("1.8") <= Version(django.__version__) < Version("1.9"):
     INSTALLED_APPS.append("django_lifecycle")
 
 


### PR DESCRIPTION
distutils is [deprecated in python 3.10+](https://www.python.org/dev/peps/pep-0632/) and will be removed in 3.12.

This replaces the current distutils based version checking with packaging and fixes deprecation warnings like:

```
.../.venv/lib/python3.10/site-packages/django_lifecycle/django_info.py:7: DeprecationWarning: distutils Ver
sion classes are deprecated. Use packaging.version instead.
    if StrictVersion(django.__version__) < StrictVersion("1.9"):
```