### PR TITLE
Add optional `@hook` `on_commit` argument to for executing hooks `on_commit`

### DIFF
--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -200,6 +200,8 @@ class LifecycleModelMixin(object):
             for callback_specs in method._hooked:
                 if callback_specs["hook"] != hook:
                     continue
+                
+                on_commit = callback_specs.get("on_commit", False)
 
                 when_field = callback_specs.get("when")
                 when_any_field = callback_specs.get("when_any")
@@ -225,10 +227,26 @@ class LifecycleModelMixin(object):
                         ]
                     ):
                         continue
+                
+                # Save method name before potentially wrapping with `on_commit`
+                method_name = method.__name__
+    
+                # Apply `on_commit` after saving the method as `fired` to preserve
+                # the non-anonymous name
+                if on_commit:
+                    # Append `_on_commit` to the existing method name to allow for firing
+                    # the same hook within the atomic transaction and on_commit
+                    method_name = method_name + "_on_commit"
+
+                    def _on_commit_func():
+                        method(self)
+                        
+                    transaction.on_commit(_on_commit_func)
+                else:
+                    method(self)
 
                 # Only call the method once per hook
-                fired.append(method.__name__)
-                method(self)
+                fired.append(method_name)
                 break
 
         return fired

--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -1,4 +1,4 @@
-from functools import reduce, lru_cache
+from functools import partial, reduce, lru_cache
 from inspect import isfunction
 from typing import Any, List
 
@@ -238,9 +238,10 @@ class LifecycleModelMixin(object):
                     # the same hook within the atomic transaction and on_commit
                     method_name = method_name + "_on_commit"
 
-                    def _on_commit_func():
-                        method(self)
-                        
+                    # Use partial to create a function closure that binds `self`
+                    # to ensure its available to execute later.
+                    _on_commit_func = partial(method, self)
+                    _on_commit_func.__name__ = method_name
                     transaction.on_commit(_on_commit_func)
                 else:
                     method(self)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,6 +28,14 @@ Or you want to email a user when their account is deleted. You could add the dec
         )
 ```
 
+Or if you want to enqueue a background job that depends on state being committed to your database
+
+```python
+    @hook(AFTER_CREATE, on_commit=True)
+    def do_after_create_jobs(self):
+        enqueue_job(send_item_shipped_notication, self.item_id)
+```
+
 Read on to see how to only fire the hooked method if certain conditions about the model's current and previous state are met.
 
 ## Transitions between specific values

--- a/docs/hooks_and_conditions.md
+++ b/docs/hooks_and_conditions.md
@@ -17,6 +17,7 @@ You can hook into one or more lifecycle moments by adding the `@hook` decorator 
         was: Any = '*', 
         was_not: Any = None,
         changes_to: Any = None,
+        on_commit: Optional[bool] = None
     ):
 ```
 ## Lifecycle Moments
@@ -52,3 +53,4 @@ If you do not use any conditional parameters, the hook will fire every time the 
 | was | Any | Only fire the hooked method if the value of the `when` field was equal to this value when first initialized; defaults to `*`.  |
 | was_not | Any | Only fire the hooked method if the value of the `when` field was NOT equal to this value when first initialized. |
 | changes_to | Any | Only fire the hooked method if the value of the `when` field was NOT equal to this value when first initialized but is currently equal to this value. |
+| on_commit | bool | When `True` only fire the hooked method after the current database transaction has been commited or not at all. (Only applies to `AFTER_*` hooks)  |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.4.1
 Click==7.0
 Django==3.2.8
+django-capture-on-commit-callbacks==1.10.0
 djangorestframework==3.11.2
 ghp-import==2.0.2
 importlib-metadata==4.8.1

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -51,7 +51,7 @@ class UserAccount(LifecycleModel):
     def timestamp_joined_at(self):
         self.joined_at = timezone.now()
 
-    @hook("after_create")
+    @hook("after_create", on_commit=True)
     def do_after_create_jobs(self):
         # queue background job to process thumbnail image...
         mail.send_mail(
@@ -75,7 +75,7 @@ class UserAccount(LifecycleModel):
     def ensure_last_name_is_not_changed_to_flanders(self):
         raise CannotRename("Oh, not Flanders. Anybody but Flanders.")
 
-    @hook("after_update", when="organization.name", has_changed=True)
+    @hook("after_update", when="organization.name", has_changed=True, on_commit=True)
     def notify_org_name_change(self):
         mail.send_mail(
             "The name of your organization has changed!",

--- a/tests/testapp/tests/test_mixin.py
+++ b/tests/testapp/tests/test_mixin.py
@@ -366,3 +366,85 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(account.has_changed("first_name"))
         account.save()
         self.assertFalse(account.has_changed("first_name"))
+
+    def test_run_hooked_methods_for_on_commit(self):
+        instance = UserAccount(first_name="Bob")
+
+        instance._potentially_hooked_methods = MagicMock(
+            return_value = [
+                MagicMock(
+                    __name__="method_that_fires_on_commit",
+                    _hooked=[
+                        {
+                            "hook": "after_create",
+                            "when": None,
+                            "when_any": None,
+                            "has_changed": None,
+                            "is_now": "*",
+                            "is_not": NotSet,
+                            "was": "*",
+                            "was_not": NotSet,
+                            "changes_to": NotSet,
+                            "on_commit": True
+                        }
+                    ],
+                ),
+                MagicMock(
+                    __name__="method_that_fires_in_transaction",
+                    _hooked=[
+                        {
+                            "hook": "after_create",
+                            "when": None,
+                            "when_any": None,
+                            "has_changed": None,
+                            "is_now": "*",
+                            "is_not": NotSet,
+                            "was": "*",
+                            "was_not": NotSet,
+                            "changes_to": NotSet,
+                            "on_commit": False
+                        }
+                    ],
+                ),
+                MagicMock(
+                    __name__="method_that_fires_in_default",
+                    _hooked=[
+                        {
+                            "hook": "after_create",
+                            "when": None,
+                            "when_any": None,
+                            "has_changed": None,
+                            "is_now": "*",
+                            "is_not": NotSet,
+                            "was": "*",
+                            "was_not": NotSet,
+                            "changes_to": NotSet,
+                            "on_commit": None
+                        }
+                    ],
+                ),
+                MagicMock(
+                    __name__="after_save_method_that_fires_on_commit",
+                    _hooked=[
+                        {
+                            "hook": "after_save",
+                            "when": None,
+                            "when_any": None,
+                            "has_changed": None,
+                            "is_now": "*",
+                            "is_not": NotSet,
+                            "was": "*",
+                            "was_not": NotSet,
+                            "changes_to": NotSet,
+                            "on_commit": True
+                        }
+                    ],
+                ),
+            ]
+        )
+
+        fired_methods = instance._run_hooked_methods("after_create")
+        self.assertEqual(fired_methods, ["method_that_fires_on_commit_on_commit", "method_that_fires_in_transaction", "method_that_fires_in_default"])
+
+        fired_methods = instance._run_hooked_methods("after_save")
+        self.assertEqual(fired_methods, ["after_save_method_that_fires_on_commit_on_commit"])


### PR DESCRIPTION
This is my attempt to address #97. 

```python
    @hook(AFTER_CREATE, on_commit=True)
    def do_after_create_jobs(self):
        enqueue_job(send_item_shipped_notication, self.item_id)
```

Instead of adding a new hook or new global configuration I ended up settling on what amounts to a nice way to use [django.db.transaction.on_commit](https://docs.djangoproject.com/en/3.2/topics/db/transactions/#django.db.transaction.on_commit) with `django-lifecycle` hooks.

The only thing in here that might be a little odd is that I needed to use `functools.partial` to make sure the model instance stayed in scope to actually execute during the `on_commit` callback.

Happy to make any small adjustments you might want, or if you don't think this is the right approach I can just keep using the version I've vendored in to my app.