### PR TITLE
refactor decorator into a dataclass

### DIFF
--- a/django_lifecycle/dataclass_validation.py
+++ b/django_lifecycle/dataclass_validation.py
@@ -20,11 +20,13 @@ class Validations:
         """
         for name, field in self.__dataclass_fields__.items():
             validator_name = f"validate_{name}"
-            if method := getattr(self, validator_name, None):
+            method = getattr(self, validator_name, None)
+            if callable(method):
                 logger.debug(f"Calling validator: {validator_name}")
                 new_value = method(getattr(self, name), field=field)
                 setattr(self, name, new_value)
 
-        if (validate := getattr(self, "validate", None)) and callable(validate):
+        validate = getattr(self, "validate", None)
+        if callable(validate):
             logger.debug(f"Calling validator: validate")
             validate()

--- a/django_lifecycle/dataclass_validation.py
+++ b/django_lifecycle/dataclass_validation.py
@@ -1,0 +1,30 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Validations:
+    # Snippet grabbed from:
+    # https://gist.github.com/rochacbruno/978405e4839142e409f8402eece505e8
+
+    def __post_init__(self):
+        """
+        Run validation methods if declared.
+        The validation method can be a simple check
+        that raises ValueError or a transformation to
+        the field value.
+        The validation is performed by calling a function named:
+            `validate_<field_name>(self, value, field) -> field.type`
+
+        Finally, calls (if defined) `validate(self)` for validations that depend on other fields
+        """
+        for name, field in self.__dataclass_fields__.items():
+            validator_name = f"validate_{name}"
+            if method := getattr(self, validator_name, None):
+                logger.debug(f"Calling validator: {validator_name}")
+                new_value = method(getattr(self, name), field=field)
+                setattr(self, name, new_value)
+
+        if (validate := getattr(self, "validate", None)) and callable(validate):
+            logger.debug(f"Calling validator: validate")
+            validate()

--- a/django_lifecycle/decorators.py
+++ b/django_lifecycle/decorators.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass, field
 from functools import wraps
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from django_lifecycle import NotSet
 
@@ -10,66 +11,68 @@ class DjangoLifeCycleException(Exception):
     pass
 
 
-def _validate_hook_params(hook, when, when_any, has_changed, on_commit):
-    if hook not in VALID_HOOKS:
-        raise DjangoLifeCycleException(
-            "%s is not a valid hook; must be one of %s" % (hook, VALID_HOOKS)
-        )
+@dataclass
+class HookConfig:
+    hook: str
+    when: Optional[str] = None
+    when_any: Optional[List[str]] = None
+    was: Any = "*"
+    is_now: Any = "*"
+    has_changed: Optional[bool] = None
+    is_not: Any = NotSet
+    was_not: Any = NotSet
+    changes_to: Any = NotSet
+    on_commit: bool = False
 
-    if has_changed is not None and not isinstance(has_changed, bool):
-        raise DjangoLifeCycleException("'has_changed' hook param must be a boolean")
-
-    if when is not None and not isinstance(when, str):
-        raise DjangoLifeCycleException(
-            "'when' hook param must be a string matching the name of a model field"
-        )
-
-    if when_any is not None:
-        when_any_error_msg = (
-            "'when_any' hook param must be a list of strings "
-            "matching the names of model fields"
-        )
-
-        if not isinstance(when_any, list):
-            raise DjangoLifeCycleException(when_any_error_msg)
-
-        if len(when_any) == 0:
+    def __post_init__(self):
+        if self.hook not in VALID_HOOKS:
             raise DjangoLifeCycleException(
-                "'when_any' hook param must contain at least one field name"
+                "%s is not a valid hook; must be one of %s" % (hook, VALID_HOOKS)
             )
 
-        for field_name in when_any:
-            if not isinstance(field_name, str):
+        if self.has_changed is not None and not isinstance(self.has_changed, bool):
+            raise DjangoLifeCycleException("'has_changed' hook param must be a boolean")
+
+        if self.when is not None and not isinstance(self.when, str):
+            raise DjangoLifeCycleException(
+                "'when' hook param must be a string matching the name of a model field"
+            )
+
+        if self.when_any is not None:
+            when_any_error_msg = (
+                "'when_any' hook param must be a list of strings "
+                "matching the names of model fields"
+            )
+
+            if not isinstance(self.when_any, list):
                 raise DjangoLifeCycleException(when_any_error_msg)
 
-    if when is not None and when_any is not None:
-        raise DjangoLifeCycleException(
-            "Can pass either 'when' or 'when_any' but not both"
-        )
-    
-    if on_commit is not None:
-        if not hook.startswith("after_"):
-            raise DjangoLifeCycleException("'on_commit' hook param is only valid with AFTER_* hooks")
+            if len(self.when_any) == 0:
+                raise DjangoLifeCycleException(
+                    "'when_any' hook param must contain at least one field name"
+                )
 
-        if not isinstance(on_commit, bool):
-            raise DjangoLifeCycleException("'on_commit' hook param must be a boolean")
+            for field_name in self.when_any:
+                if not isinstance(field_name, str):
+                    raise DjangoLifeCycleException(when_any_error_msg)
 
+        if self.when is not None and self.when_any is not None:
+            raise DjangoLifeCycleException(
+                "Can pass either 'when' or 'when_any' but not both"
+            )
 
-def hook(
-    hook: str,
-    when: str = None,
-    when_any: List[str] = None,
-    was="*",
-    is_now="*",
-    has_changed: bool = None,
-    is_not=NotSet,
-    was_not=NotSet,
-    changes_to=NotSet,
-    on_commit: Optional[bool] = None
-):
-    _validate_hook_params(hook, when, when_any, has_changed, on_commit)
+        if self.on_commit:
+            if not self.hook.startswith("after_"):
+                raise DjangoLifeCycleException(
+                    "'on_commit' hook param is only valid with AFTER_* hooks"
+                )
 
-    def decorator(hooked_method):
+            if not isinstance(self.on_commit, bool):
+                raise DjangoLifeCycleException(
+                    "'on_commit' hook param must be a boolean"
+                )
+
+    def __call__(self, hooked_method):
         if not hasattr(hooked_method, "_hooked"):
 
             @wraps(hooked_method)
@@ -80,21 +83,9 @@ def hook(
         else:
             func = hooked_method
 
-        func._hooked.append(
-            {
-                "hook": hook,
-                "when": when,
-                "when_any": when_any,
-                "has_changed": has_changed,
-                "is_now": is_now,
-                "is_not": is_not,
-                "was": was,
-                "was_not": was_not,
-                "changes_to": changes_to,
-                "on_commit": on_commit
-            }
-        )
+        func._hooked.append(self)
 
         return func
 
-    return decorator
+
+hook = HookConfig  # keep backwards compatibility

--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.utils.functional import cached_property
 
 from . import NotSet
+from .decorators import HookConfig
 from .hooks import (
     BEFORE_CREATE,
     BEFORE_UPDATE,
@@ -177,9 +178,9 @@ class LifecycleModelMixin(object):
         watched = []  # List[str]
 
         for method in cls._potentially_hooked_methods():
-            for specs in method._hooked:
-                if specs["when"] is not None and "." in specs["when"]:
-                    watched.append(specs["when"])
+            for hook_config in method._hooked:
+                if hook_config.when is not None and "." in hook_config.when:
+                    watched.append(hook_config.when)
 
         return watched
 
@@ -198,13 +199,13 @@ class LifecycleModelMixin(object):
 
         for method in self._potentially_hooked_methods():
             for callback_specs in method._hooked:
-                if callback_specs["hook"] != hook:
+                if callback_specs.hook != hook:
                     continue
-                
-                on_commit = callback_specs.get("on_commit", False)
 
-                when_field = callback_specs.get("when")
-                when_any_field = callback_specs.get("when_any")
+                on_commit = callback_specs.on_commit
+
+                when_field = callback_specs.when
+                when_any_field = callback_specs.when_any
                 update_fields = kwargs.get("update_fields", None)
                 is_partial_fields_update = update_fields is not None
 
@@ -235,10 +236,10 @@ class LifecycleModelMixin(object):
 
                     if not any_condition_matched:
                         continue
-                
+
                 # Save method name before potentially wrapping with `on_commit`
                 method_name = method.__name__
-    
+
                 # Apply `on_commit` after saving the method as `fired` to preserve
                 # the non-anonymous name
                 if on_commit:
@@ -283,34 +284,34 @@ class LifecycleModelMixin(object):
 
         return True
 
-    def _check_has_changed(self, field_name: str, specs: dict, is_synced: bool) -> bool:
+    def _check_has_changed(self, field_name: str, specs: HookConfig, is_synced: bool) -> bool:
         if not is_synced:
             return False
 
-        has_changed = specs["has_changed"]
+        has_changed = specs.has_changed
         return has_changed is None or has_changed == self.has_changed(field_name)
 
-    def _check_is_now_condition(self, field_name: str, specs: dict) -> bool:
-        return specs["is_now"] in (self._current_value(field_name), "*")
+    def _check_is_now_condition(self, field_name: str, specs: HookConfig) -> bool:
+        return specs.is_now in (self._current_value(field_name), "*")
 
-    def _check_is_not_condition(self, field_name: str, specs: dict) -> bool:
-        is_not = specs["is_not"]
+    def _check_is_not_condition(self, field_name: str, specs: HookConfig) -> bool:
+        is_not = specs.is_not
         return is_not is NotSet or self._current_value(field_name) != is_not
 
-    def _check_was_condition(self, field_name: str, specs: dict) -> bool:
-        return specs["was"] in (self.initial_value(field_name), "*")
+    def _check_was_condition(self, field_name: str, specs: HookConfig) -> bool:
+        return specs.was in (self.initial_value(field_name), "*")
 
-    def _check_was_not_condition(self, field_name: str, specs: dict) -> bool:
-        was_not = specs["was_not"]
+    def _check_was_not_condition(self, field_name: str, specs: HookConfig) -> bool:
+        was_not = specs.was_not
         return was_not is NotSet or self.initial_value(field_name) != was_not
 
     def _check_changes_to_condition(
-        self, field_name: str, specs: dict, is_synced: bool
+        self, field_name: str, specs: HookConfig, is_synced: bool
     ) -> bool:
         if not is_synced:
             return False
 
-        changes_to = specs["changes_to"]
+        changes_to = specs.changes_to
         return any(
             [
                 changes_to is NotSet,

--- a/tests/testapp/tests/test_mixin.py
+++ b/tests/testapp/tests/test_mixin.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 from django_lifecycle import NotSet
+from django_lifecycle.decorators import HookConfig
 from tests.testapp.models import CannotRename, Organization, UserAccount
 
 
@@ -98,33 +99,15 @@ class LifecycleMixinTests(TestCase):
                 MagicMock(
                     __name__="method_that_does_fires",
                     _hooked=[
-                        {
-                            "hook": "after_create",
-                            "when": "first_name",
-                            "when_any": None,
-                            "has_changed": None,
-                            "is_now": "Bob",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                        }
+                        HookConfig(hook="after_create", when="first_name", when_any=None, has_changed=None, is_now="Bob",
+                             is_not=NotSet, was="*", was_not=NotSet, changes_to=NotSet)
                     ],
                 ),
                 MagicMock(
                     __name__="method_that_does_not_fire",
                     _hooked=[
-                        {
-                            "hook": "after_create",
-                            "when": "first_name",
-                            "when_any": None,
-                            "has_changed": None,
-                            "is_now": "Bill",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                        }
+                        HookConfig(hook="after_create", when="first_name", when_any=None, has_changed=None, is_now="Bill",
+                             is_not=NotSet, was="*", was_not=NotSet, changes_to=NotSet)
                     ],
                 ),
             ]
@@ -140,33 +123,15 @@ class LifecycleMixinTests(TestCase):
                 MagicMock(
                     __name__="method_that_does_fires",
                     _hooked=[
-                        {
-                            "hook": "after_create",
-                            "when": None,
-                            "when_any": ["first_name", "last_name", "password"],
-                            "has_changed": None,
-                            "is_now": "Bob",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                        }
+                        HookConfig(hook="after_create", when=None, when_any=["first_name", "last_name", "password"],
+                             has_changed=None, is_now="Bob", is_not=NotSet, was="*", was_not=NotSet, changes_to=NotSet)
                     ],
                 ),
                 MagicMock(
                     __name__="method_that_does_not_fire",
                     _hooked=[
-                        {
-                            "hook": "after_create",
-                            "when": "first_name",
-                            "when_any": None,
-                            "has_changed": None,
-                            "is_now": "Bill",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                        }
+                        HookConfig(hook="after_create", when="first_name", when_any=None, has_changed=None, is_now="Bill",
+                             is_not=NotSet, was="*", was_not=NotSet, changes_to=NotSet)
                     ],
                 ),
             ]
@@ -201,7 +166,7 @@ class LifecycleMixinTests(TestCase):
         self.assertFalse(user_account.has_changed("organization.name"))
 
     def test_has_changed_specs(self):
-        specs = {"when": "first_name", "has_changed": True}
+        specs = HookConfig("before_update", when="first_name", has_changed=True)
 
         data = self.stub_data
         data["first_name"] = "Homer"
@@ -213,7 +178,7 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(user_account._check_has_changed("first_name", specs, True))
 
     def test_check_is_now_condition_wildcard_should_pass(self):
-        specs = {"when": "first_name", "is_now": "*"}
+        specs = HookConfig("before_update", when="first_name", is_now="*")
         data = self.stub_data
         data["first_name"] = "Homer"
         UserAccount.objects.create(**data)
@@ -222,7 +187,7 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(user_account._check_is_now_condition("first_name", specs))
 
     def test_check_is_now_condition_matching_value_should_pass(self):
-        specs = {"when": "first_name", "is_now": "Ned"}
+        specs = HookConfig("before_update", when="first_name", is_now="Ned")
         data = self.stub_data
         data["first_name"] = "Homer"
         UserAccount.objects.create(**data)
@@ -231,7 +196,7 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(user_account._check_is_now_condition("first_name", specs))
 
     def test_check_is_now_condition_not_matched_value_should_not_pass(self):
-        specs = {"when": "first_name", "is_now": "Bart"}
+        specs = HookConfig("before_update", when="first_name", is_now="Bart")
         data = self.stub_data
         data["first_name"] = "Homer"
         UserAccount.objects.create(**data)
@@ -239,14 +204,14 @@ class LifecycleMixinTests(TestCase):
         self.assertFalse(user_account._check_is_now_condition("first_name", specs))
 
     def test_check_was_not_condition_should_pass_when_not_set(self):
-        specs = {"when": "first_name", "was_not": NotSet}
+        specs = HookConfig("before_update", when="first_name", was_not=NotSet)
         data = self.stub_data
         UserAccount.objects.create(**data)
         user_account = UserAccount.objects.get()
         self.assertTrue(user_account._check_was_not_condition("first_name", specs))
 
     def test_check_was_not_condition_not_matching_value_should_pass(self):
-        specs = {"when": "first_name", "was_not": "Bart"}
+        specs = HookConfig("before_update", when="first_name", was_not="Bart")
 
         data = self.stub_data
         data["first_name"] = "Homer"
@@ -255,7 +220,7 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(user_account._check_was_not_condition("first_name", specs))
 
     def test_check_was_not_condition_matched_value_should_not_pass(self):
-        specs = {"when": "first_name", "was_not": "Homer"}
+        specs = HookConfig("before_update", when="first_name", was_not="Homer")
 
         data = self.stub_data
         data["first_name"] = "Homer"
@@ -264,7 +229,7 @@ class LifecycleMixinTests(TestCase):
         self.assertFalse(user_account._check_was_not_condition("first_name", specs))
 
     def test_check_was_condition_wildcard_should_pass(self):
-        specs = {"when": "first_name", "was": "*"}
+        specs = HookConfig("before_update", when="first_name", was="*")
 
         data = self.stub_data
         data["first_name"] = "Homer"
@@ -273,7 +238,7 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(user_account._check_was_condition("first_name", specs))
 
     def test_check_was_condition_matching_value_should_pass(self):
-        specs = {"when": "first_name", "was": "Homer"}
+        specs = HookConfig("before_update", when="first_name", was="Homer")
 
         data = self.stub_data
         data["first_name"] = "Homer"
@@ -282,7 +247,7 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(user_account._check_was_condition("first_name", specs))
 
     def test_check_was_condition_not_matched_value_should_not_pass(self):
-        specs = {"when": "first_name", "was": "Bart"}
+        specs = HookConfig("before_update", when="first_name", was="Bart")
 
         data = self.stub_data
         data["first_name"] = "Homer"
@@ -291,7 +256,7 @@ class LifecycleMixinTests(TestCase):
         self.assertFalse(user_account._check_was_condition("first_name", specs))
 
     def test_is_not_condition_should_pass(self):
-        specs = {"when": "first_name", "is_not": "Ned"}
+        specs = HookConfig("before_update", when="first_name", is_not="Ned")
 
         data = self.stub_data
         data["first_name"] = "Homer"
@@ -300,7 +265,7 @@ class LifecycleMixinTests(TestCase):
         self.assertTrue(user_account._check_is_not_condition("first_name", specs))
 
     def test_is_not_condition_should_not_pass(self):
-        specs = {"when": "first_name", "is_not": "Ned"}
+        specs = HookConfig("before_update", when="first_name", is_not="Ned")
 
         data = self.stub_data
         data["first_name"] = "Ned"
@@ -383,69 +348,29 @@ class LifecycleMixinTests(TestCase):
                 MagicMock(
                     __name__="method_that_fires_on_commit",
                     _hooked=[
-                        {
-                            "hook": "after_create",
-                            "when": None,
-                            "when_any": None,
-                            "has_changed": None,
-                            "is_now": "*",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                            "on_commit": True
-                        }
+                        HookConfig(hook="after_create", when=None, when_any=None, has_changed=None, is_now="*", is_not=NotSet,
+                             was="*", was_not=NotSet, changes_to=NotSet, on_commit=True)
                     ],
                 ),
                 MagicMock(
                     __name__="method_that_fires_in_transaction",
                     _hooked=[
-                        {
-                            "hook": "after_create",
-                            "when": None,
-                            "when_any": None,
-                            "has_changed": None,
-                            "is_now": "*",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                            "on_commit": False
-                        }
+                        HookConfig(hook="after_create", when=None, when_any=None, has_changed=None, is_now="*", is_not=NotSet,
+                             was="*", was_not=NotSet, changes_to=NotSet, on_commit=False)
                     ],
                 ),
                 MagicMock(
                     __name__="method_that_fires_in_default",
                     _hooked=[
-                        {
-                            "hook": "after_create",
-                            "when": None,
-                            "when_any": None,
-                            "has_changed": None,
-                            "is_now": "*",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                            "on_commit": None
-                        }
+                        HookConfig(hook="after_create", when=None, when_any=None, has_changed=None, is_now="*", is_not=NotSet,
+                             was="*", was_not=NotSet, changes_to=NotSet, on_commit=None)
                     ],
                 ),
                 MagicMock(
                     __name__="after_save_method_that_fires_on_commit",
                     _hooked=[
-                        {
-                            "hook": "after_save",
-                            "when": None,
-                            "when_any": None,
-                            "has_changed": None,
-                            "is_now": "*",
-                            "is_not": NotSet,
-                            "was": "*",
-                            "was_not": NotSet,
-                            "changes_to": NotSet,
-                            "on_commit": True
-                        }
+                        HookConfig(hook="after_save", when=None, when_any=None, has_changed=None, is_now="*", is_not=NotSet,
+                             was="*", was_not=NotSet, changes_to=NotSet, on_commit=True)
                     ],
                 ),
             ]


### PR DESCRIPTION
Maybe it's a bit unnecessary, but I think that by converting the decorator into a class it will be easier to extend the functionality and keep it simpler. Also, we gain autocompletion on our IDEs.

Also, I've separated each validation in it's own method
