### PR TITLE
Initial setup of CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+---
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+
+      - name: Lint
+        continue-on-error: true
+        run: |
+          pip install black flake8
+          flake8 . --exclude=venv/,.tox/,django_lifecycle/__init__.py
+          black --check django-lifecyle tests
+
+      - name: Run tests
+        run: |
+          pip install tox tox-gh-actions
+          tox

--- a/tests/testapp/tests/test_user_account.py
+++ b/tests/testapp/tests/test_user_account.py
@@ -26,8 +26,8 @@ class UserAccountTestCase(TestCase):
     def test_send_welcome_email_after_create(self):
         with capture_on_commit_callbacks(execute=True) as callbacks:
             UserAccount.objects.create(**self.stub_data)
-        
-        self.assertEquals(len(callbacks), 1, msg=f"{callbacks}")
+
+        self.assertEqual(len(callbacks), 1, msg=f"{callbacks}")
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Welcome!")
 
@@ -86,8 +86,8 @@ class UserAccountTestCase(TestCase):
             org.save()
 
             account.save()
-        
-        self.assertEquals(len(callbacks), 1)
+
+        self.assertEqual(len(callbacks), 1)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
             mail.outbox[0].subject, "The name of your organization has changed!"
@@ -115,7 +115,7 @@ class UserAccountTestCase(TestCase):
 
             account.save()
 
-        self.assertEquals(len(callbacks), 1, msg="Only one hook should be an on_commit callback")
+        self.assertEqual(len(callbacks), 1, msg="Only one hook should be an on_commit callback")
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(
             mail.outbox[1].subject, "The name of your organization has changed!"
@@ -179,9 +179,10 @@ class UserAccountTestCase(TestCase):
 
     def test_delete_should_return_default_django_value(self):
         """
-        Hooked method that auto-lowercases email should be skipped.
+        Note that `QuerySet.delete()` does a bulk delete and does not call any `delete()` methods on your models.
         """
-        UserAccount.objects.create(**self.stub_data)
-        value = UserAccount.objects.all().delete()
+        account = UserAccount.objects.create(**self.stub_data)
+        count, count_per_type = account.delete()
 
-        self.assertEqual(value, (1, {"testapp.UserAccount": 1}))
+        self.assertEqual(count, 1)
+        self.assertEqual(count_per_type["testapp.UserAccount"], 1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,19 @@
 [tox]
 toxworkdir={env:TOXWORKDIR:{toxinidir}/.tox}
 envlist =
-    {py35,py36,py37}-django20
-    {py35,py36,py37}-django21
-    {py35,py36,py37,py38,py39}-django22
-    {py36,py37,py38,py39}-django30
-    {py36,py37,py38,py39}-django31
+    {py37}-django20
+    {py37}-django21
+    {py37,py38,py39}-django22
+    {py37,py38,py39}-django30
+    {py37,py38,py39}-django31
     flake8
 skip_missing_interpreters = True
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
 
 [flake8]
 max-line-length = 120
@@ -20,12 +26,15 @@ setenv =
     PYTHONWARNINGS=once
     DJANGO_SETTINGS_MODULE=tests.settings
 deps =
+    django{20,21}: django-capture-on-commit-callbacks==1.1.0
+    django{22,30,31}: django-capture-on-commit-callbacks==1.10.0
+    django32: django-capture-on-commit-callbacks==1.11.0
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2,<3
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
-    django31: django>=3.2,<3.3
+    django32: django>=3.2,<3.3
 
 [testenv:flake8]
 basepython = python3.7


### PR DESCRIPTION
The objective here is to get a working CI workflow setup using GitHub Actions as a replacement for Travis CI. This is prep work for additional changes in the pipeline, i.e. sun setting older Django versions and supporting newer ones and any other changes.

I wanted to have the tests passing (using tox) under the supported Python versions (3.7, 3.8, 3.9). An example of a successful run is here: https://github.com/emiel/django-lifecycle/actions/runs/2585559370.

The "Lint" job is an example of what could be done and we'd need to decide on what exactly we want to enforce. I tried to mimic what was already there for Travis. It is allowed to fail at the moment and we should come back to this.

See the individual commit messages for more details.

Addresses issue #100.

Let me know if you need more info.