### PR TITLE
fix(sec): upgrade Django to 4.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.4.1
 Click==7.0
-Django==3.2.8
+Django==4.0.6
 django-capture-on-commit-callbacks==1.10.0
 djangorestframework==3.11.2
 ghp-import==2.0.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in Django 3.2.8
- [CVE-2022-34265](https://www.oscs1024.com/hd/CVE-2022-34265)


### What did I do？
Upgrade Django from 3.2.8 to 4.0.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS