### PR TITLE
Reset initial state using a on_commit transaction

### DIFF
--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -148,6 +148,9 @@ class LifecycleModelMixin(object):
             if field.is_relation and field.is_cached(self):
                 field.delete_cached_value(self)
 
+    def _reset_initial_state(self):
+        self._initial_state = self._snapshot_state()
+
     @transaction.atomic
     def save(self, *args, **kwargs):
         skip_hooks = kwargs.pop("skip_hooks", False)
@@ -174,7 +177,7 @@ class LifecycleModelMixin(object):
         else:
             self._run_hooked_methods(AFTER_UPDATE, **kwargs)
 
-        self._initial_state = self._snapshot_state()
+        transaction.on_commit(self._reset_initial_state)
 
     @transaction.atomic
     def delete(self, *args, **kwargs):

--- a/tests/testapp/tests/test_mixin.py
+++ b/tests/testapp/tests/test_mixin.py
@@ -377,6 +377,10 @@ class LifecycleMixinTests(TestCase):
                              was="*", was_not=NotSet, changes_to=NotSet, on_commit=True, priority=DEFAULT_PRIORITY)
                     ],
                 ),
+                MagicMock(
+                    __name__="after_save_method_that_fires_if_changed_on_commit",
+                    _hooked=[HookConfig(hook="after_save", has_changed=True, on_commit=True)],
+                ),
             ]
         )
 
@@ -384,4 +388,10 @@ class LifecycleMixinTests(TestCase):
         self.assertEqual(fired_methods, ["method_that_fires_on_commit_on_commit", "method_that_fires_in_transaction", "method_that_fires_in_default"])
 
         fired_methods = instance._run_hooked_methods("after_save")
-        self.assertEqual(fired_methods, ["after_save_method_that_fires_on_commit_on_commit"])
+        self.assertEqual(
+            fired_methods,
+            [
+                "after_save_method_that_fires_on_commit_on_commit",
+                "after_save_method_that_fires_if_changed_on_commit_on_commit",
+            ]
+        )

--- a/tests/testapp/tests/test_user_account.py
+++ b/tests/testapp/tests/test_user_account.py
@@ -31,6 +31,21 @@ class UserAccountTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Welcome!")
 
+    def test_initial_values_on_commit_hook(self):
+        initial_email = "homer.simpson@springfieldnuclear.com"
+        account = UserAccount.objects.create(**self.stub_data, email=initial_email)
+
+        new_email = "homer.thompson@springfieldnuclear.com"
+        account.email = new_email
+        with capture_on_commit_callbacks(execute=True):
+            account.save()
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            mail.outbox[0].body,
+            account.build_email_changed_body(old_email=initial_email, new_email=new_email)
+        )
+
     def test_email_banned_user_after_update(self):
         account = UserAccount.objects.create(status="active", **self.stub_data)
         account.refresh_from_db()

--- a/tests/testapp/tests/test_user_account.py
+++ b/tests/testapp/tests/test_user_account.py
@@ -26,8 +26,8 @@ class UserAccountTestCase(TestCase):
     def test_send_welcome_email_after_create(self):
         with capture_on_commit_callbacks(execute=True) as callbacks:
             UserAccount.objects.create(**self.stub_data)
-        
-        self.assertEquals(len(callbacks), 1, msg=f"{callbacks}")
+
+        self.assertEquals(len(callbacks), 2, msg=f"{callbacks}")
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Welcome!")
 
@@ -86,8 +86,8 @@ class UserAccountTestCase(TestCase):
             org.save()
 
             account.save()
-        
-        self.assertEquals(len(callbacks), 1)
+
+        self.assertEquals(len(callbacks), 3)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
             mail.outbox[0].subject, "The name of your organization has changed!"
@@ -115,7 +115,7 @@ class UserAccountTestCase(TestCase):
 
             account.save()
 
-        self.assertEquals(len(callbacks), 1, msg="Only one hook should be an on_commit callback")
+        self.assertEquals(len(callbacks), 3, msg="One hook and the _reset_initial_state (2) should be in the on_commit callbacks")
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(
             mail.outbox[1].subject, "The name of your organization has changed!"


### PR DESCRIPTION
After saving an instance, reset the `_initial_state` using a `on_commit` callback. This makes the `has_changed` and `initial_value` API work with hooks that run with `on_commit=True`.


Fixes #117 