### PR TITLE
🚧chore: Add support for Django 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This project provides a `@hook` decorator as well as a base model and mixin to add lifecycle hooks to your Django models. Django's built-in approach to offering lifecycle hooks is [Signals](https://docs.djangoproject.com/en/dev/topics/signals/). However, my team often finds that Signals introduce unnecessary indirection and are at odds with Django's "fat models" approach.
 
-**Django Lifecycle Hooks** supports Python 3.7, 3.8 and 3.9, Django 2.0.x, 2.1.x, 2.2.x, 3.0.x, 3.1.x, and 3.2.x.
+**Django Lifecycle Hooks** supports Python 3.7, 3.8, 3.9, and 3.10, Django 2.0.x, 2.1.x, 2.2.x, 3.0.x, 3.1.x, 3.2.x, 4.0.x, 4.1.x, and 4.2.x.
 
 In short, you can write model code like this:
 
@@ -60,6 +60,10 @@ Instead of overriding `save` and `__init__` in a clunky way that hurts readabili
 ---
 
 # Changelog
+
+## 1.0.2 (September 2023)
+
+- Correct package info to note that Django 4.0, 4.1, and 4.2 are supported.
 
 ## 1.0.1 (August 2023)
 

--- a/django_lifecycle/__init__.py
+++ b/django_lifecycle/__init__.py
@@ -1,6 +1,6 @@
 from .django_info import IS_GTE_1_POINT_9
 
-__version__ = "1.0.0"
+__version__ = "1.0.2"
 __author__ = "Robert Singer"
 __author_email__ = "robertgsinger@gmail.com"
 
@@ -10,9 +10,9 @@ class NotSet(object):
 
 
 from .decorators import hook
-from .mixins import LifecycleModelMixin
 from .hooks import *
-
+from .mixins import LifecycleModelMixin
 
 if IS_GTE_1_POINT_9:
     from .models import LifecycleModel
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.4.1
 Click==7.0
-Django==3.2.8
+Django==4.2.4
 django-capture-on-commit-callbacks==1.10.0
 djangorestframework==3.11.2
 ghp-import==2.0.2

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Framework :: Django",
     "Framework :: Django :: 2.0",
     "Framework :: Django :: 2.1",
@@ -37,6 +38,9 @@ classifiers = [
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
 ]
 setup(
     name="django-lifecycle",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,9 +11,9 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
 import os
-from packaging.version import Version
 
 import django
+from packaging.version import Version
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -120,3 +120,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
 STATIC_URL = "/static/"
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,10 @@ envlist =
     {py35,py36,py37,py38,py39}-django22
     {py36,py37,py38,py39}-django30
     {py36,py37,py38,py39}-django31
+    {py36,py37,py38,py39,py310}-django32
+    {py38,py39,py310}-django40
+    {py38,py39,py310}-django41
+    {py38,py39,py310}-django42
     flake8
 skip_missing_interpreters = True
 
@@ -22,14 +26,17 @@ setenv =
 deps =
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
-    django22: django>=2.2,<3
+    django22: django>=2.2,<3.0
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
-    django31: django>=3.2,<3.3
+    django32: django>=3.2,<3.3
+    django40: django>=4.0,<4.1
+    django41: django>=4.1,<4.2
+    django42: django>=4.2,<4.3
 
 [testenv:flake8]
 basepython = python3.7
 deps =
     flake8==3.8.4
 commands =
-    flake8 . --exclude=venv/,.tox/,django_lifecycle/__init__.py
+    flake8 . --exclude=.venv/,venv/,.tox/,django_lifecycle/__init__.py


### PR DESCRIPTION
fixed #114

adopted some of the changes in #115

and those in https://github.com/rsinger86/django-lifecycle/compare/0.9.2...0.9.3

## PS

After this is merged, the next PR i will likely make is to drop support for Django versions that are outdated. This will be everything before 3.2 and 4.0.