### PR TITLE
Extract model state methods

### DIFF
--- a/django_lifecycle/model_state.py
+++ b/django_lifecycle/model_state.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+from typing import Dict
+from typing import TYPE_CHECKING
+
+from django_lifecycle.utils import get_value
+from django_lifecycle.utils import sanitize_field_name
+
+if TYPE_CHECKING:
+    from django_lifecycle import LifecycleModelMixin
+
+
+class ModelState:
+    def __init__(self, initial_state: Dict[str, Any]):
+        self.initial_state = initial_state
+
+    @classmethod
+    def from_instance(cls, instance: "LifecycleModelMixin") -> ModelState:
+        state = deepcopy(instance.__dict__)
+
+        for watched_related_field in instance._watched_fk_model_fields():
+            state[watched_related_field] = get_value(instance, watched_related_field)
+
+        fields_to_remove = (
+            "_state",
+            "_potentially_hooked_methods",
+            "_initial_state",
+            "_watched_fk_model_fields",
+        )
+        for field in fields_to_remove:
+            state.pop(field, None)
+
+        return ModelState(state)
+
+    def get_diff(self, instance: "LifecycleModelMixin") -> dict:
+        current = ModelState.from_instance(instance).initial_state
+        diffs = {}
+
+        for key, initial_value in self.initial_state.items():
+            try:
+                current_value = current[key]
+            except KeyError:
+                continue
+
+            if initial_value != current_value:
+                diffs[key] = (key, current_value)
+
+        return diffs
+
+    def get_value(self, instance: "LifecycleModelMixin", field_name: str) -> Any:
+        """
+        Get initial value of field when model was instantiated.
+        """
+        field_name = sanitize_field_name(instance, field_name)
+        return self.initial_state.get(field_name)
+
+    def has_changed(self, instance: "LifecycleModelMixin", field_name: str) -> bool:
+        """
+        Check if a field has changed since the model was instantiated.
+        """
+        field_name = sanitize_field_name(instance, field_name)
+        return field_name in self.get_diff(instance)

--- a/django_lifecycle/utils.py
+++ b/django_lifecycle/utils.py
@@ -1,0 +1,37 @@
+from functools import reduce
+from typing import Any
+
+from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import models
+
+
+def sanitize_field_name(instance: models.Model, field_name: str) -> str:
+    try:
+        field = instance._meta.get_field(field_name)
+
+        try:
+            internal_type = field.get_internal_type()
+        except AttributeError:
+            return field
+        if internal_type == "ForeignKey" or internal_type == "OneToOneField":
+            if not field_name.endswith("_id"):
+                return field_name + "_id"
+    except FieldDoesNotExist:
+        pass
+
+    return field_name
+
+
+def get_value(instance, sanitized_field_name: str) -> Any:
+    if "." in sanitized_field_name:
+
+        def getitem(obj, field_name: str):
+            try:
+                return getattr(obj, field_name)
+            except (AttributeError, ObjectDoesNotExist):
+                return None
+
+        return reduce(getitem, sanitized_field_name.split("."), instance)
+    else:
+        return getattr(instance, sanitize_field_name(instance, sanitized_field_name))


### PR DESCRIPTION
This is a first step into remove most of the methods present in LifecycleMixin. Those methods end up being in lifecycle users models, where, in my opinion, they don't belong.

I've left those methods for backwards compatibility, but they will be removed in the future