### PR TITLE
perf: don't eval attr just pass to isinstance

### DIFF
--- a/django_lifecycle/mixins.py
+++ b/django_lifecycle/mixins.py
@@ -267,7 +267,7 @@ class LifecycleModelMixin(object):
         for name in dir(cls):
             attr = getattr(cls, name, None)
 
-            if attr and isinstance(attr, DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES):
+            if isinstance(attr, DJANGO_RELATED_FIELD_DESCRIPTOR_CLASSES):
                 descriptor_names.append(name)
 
         return descriptor_names


### PR DESCRIPTION
Had a nasty issue where I had a large QS be a @class_property, and this code caused it to eval the QS, there's no need to eval it, just pass it directly do isinstance, if we really want a check, a `is not None` would be better. 

But would be even better if this didn't loop over all properities, rather it used

`cls._meta.related_objects`
