### PR TITLE
Update supported Python/Django versions for pypi and fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Django Lifecycle Hooks
 
-[![Package version](https://badge.fury.io/py/django-lifecycle.svg)](https://pypi.python.org/pypi/django-lifecycle)
-[![Python versions](https://img.shields.io/pypi/status/django-lifecycle.svg)](https://img.shields.io/pypi/status/django-lifecycle.svg/)
+[![Package version](https://badge.fury.io/py/django-lifecycle.svg)](https://pypi.org/project/django-lifecycle/)
+[![PyPI status](https://img.shields.io/pypi/status/django-lifecycle.svg)](https://pypi.org/project/django-lifecycle/)
 [![Python versions](https://img.shields.io/pypi/pyversions/django-lifecycle.svg)](https://pypi.org/project/django-lifecycle/)
-![PyPI - Django Version](https://img.shields.io/pypi/djversions/django-lifecycle)
+[![Django versions](https://img.shields.io/pypi/djversions/django-lifecycle)](https://pypi.org/project/django-lifecycle/)
 
 This project provides a `@hook` decorator as well as a base model and mixin to add lifecycle hooks to your Django models. Django's built-in approach to offering lifecycle hooks is [Signals](https://docs.djangoproject.com/en/dev/topics/signals/). However, my team often finds that Signals introduce unnecessary indirection and are at odds with Django's "fat models" approach.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,8 @@
 # Django Lifecycle Hooks
-
 [![Package version](https://badge.fury.io/py/django-lifecycle.svg)](https://pypi.python.org/pypi/django-lifecycle)
-[![Python versions](https://img.shields.io/pypi/status/django-lifecycle.svg)](https://img.shields.io/pypi/status/django-lifecycle.svg/)
+[![PyPI status](https://img.shields.io/pypi/status/django-lifecycle.svg)](https://pypi.org/project/django-lifecycle/)
 [![Python versions](https://img.shields.io/pypi/pyversions/django-lifecycle.svg)](https://pypi.org/project/django-lifecycle/)
-![PyPI - Django Version](https://img.shields.io/pypi/djversions/django-lifecycle)
-
+[![Django versions](https://img.shields.io/pypi/djversions/django-lifecycle)](https://pypi.org/project/django-lifecycle/)
 
 This project provides a `@hook` decorator as well as a base model and mixin to add lifecycle hooks to your Django models. Django's built-in approach to offering lifecycle hooks is [Signals](https://docs.djangoproject.com/en/dev/topics/signals/). However, my team often finds that Signals introduce unnecessary indirection and are at odds with Django's "fat models" approach.
 
@@ -50,7 +48,7 @@ Instead of overriding `save` and `__init__` in a clunky way that hurts readabili
 
 
     def save(self, *args, **kwargs):
-        if self.pk is not None and self.contents != self._orig_contents):
+        if self.pk is not None and self.contents != self._orig_contents:
             self.updated_at = timezone.now()
 
         super().save(*args, **kwargs)
@@ -61,8 +59,8 @@ Instead of overriding `save` and `__init__` in a clunky way that hurts readabili
 
 ## Requirements
 
-* Python (3.7+)
-* Django (2.2+)
+* Python (3.8+)
+* Django (4.2+)
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
 ]
 setup(
     name="django-lifecycle",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     {py38,py39,py310,py311,py312}-django42
     {py310,py311,py312}-django50
     {py310,py311,py312,py313,py314}-django52
-    {py312,py314,py313,py314}-django60
+    {py312,py313,py314}-django60
     flake8
 skip_missing_interpreters = False
 


### PR DESCRIPTION
## Sync metadata and badges for Python/Django versions

### Summary
Synchronizes pypi metadata with the current documentation.
This also makes dynamic badges accurately reflect supported versions.

### Changes
- **`setup.py`**: Added Python 3.13, 3.14 and Django 6.0 to classifiers.
- **`README.md` & `docs/`**: 
    - Fixed badge labels (correcting "PyPI status" vs "Python versions").
    - Updated legacy/broken badge links and added missing PyPI links.
- **`tox.ini`**: Removed duplicate `py314` in Django 6.0 envlist.

### Why
Metadata on pypi should be up to date.
Dynamic badges fetch metadata from `setup.py`. These changes then also ensure that the badges correctly display the support levels already claimed in the README and tested by tox combinations.
